### PR TITLE
#17 Use maven to build release jar

### DIFF
--- a/docs-to-pdf-converter/pom.xml
+++ b/docs-to-pdf-converter/pom.xml
@@ -23,6 +23,18 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>2.1.0.RELEASE</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>


### PR DESCRIPTION
just invoke: 

  mvn clean package

and in the target folder you'll find the jar file.

Note, that the jar built using maven is about 15x faster than the one built by eclipse (~2s vs. ~30s for my test file). Also, it works with java 11.
